### PR TITLE
fix/UnboundLocalError

### DIFF
--- a/agti/central_banks/base_scrapper.py
+++ b/agti/central_banks/base_scrapper.py
@@ -658,6 +658,7 @@ class BaseBankScraper:
         headers = self.get_headers()
         cookies = self.get_cookies_for_request()
         proxies = self.get_proxies()
+        resp = None
         for i in range(3):
             try:
                 resp = requests.head(url, headers=headers, cookies=cookies, proxies=proxies, allow_redirects=True, timeout=60)
@@ -698,7 +699,7 @@ class BaseBankScraper:
                 })
                 break
         # end of loop
-        if resp.status_code != 200:
+        if resp is None or resp.status_code != 200:
             logger.exception(f"Failed to get file type for {url}, status code: {resp.status_code}", extra={
                 "url": url,
                 "headers": headers,

--- a/agti/central_banks/base_scrapper.py
+++ b/agti/central_banks/base_scrapper.py
@@ -737,7 +737,17 @@ class BaseBankScraper:
         #else:
         #    output[1] = None
         return output
-        
+
+
+    @staticmethod
+    def repair_url(url):
+        """
+        Repair the URL if it is missing the protocol.
+        This is a simple heuristic to fix common mistakes.
+        """
+        if url.startswith("ttp://") or url.startswith("ttps://"):
+            return 'h' + url
+        return url
 
 
     def process_links(self, main_file_id, f_get_links, year = None, allow_outside=False, download_a_tag_xpath=None):
@@ -752,7 +762,7 @@ class BaseBankScraper:
         """
         # get all links from the main page
         all_links = [
-            (link_text, link) for link_text, link in f_get_links() if link is not None and link_text != ""
+            (link_text, self.repair_url(link)) for link_text, link in f_get_links() if link is not None and link_text != ""
         ]
         
         result = []

--- a/agti/central_banks/base_scrapper.py
+++ b/agti/central_banks/base_scrapper.py
@@ -690,6 +690,14 @@ class BaseBankScraper:
                         "http": new_proxies,
                         "https": new_proxies
                     }
+            except requests.exceptions.InvalidSchema as e:
+                logger.exception(f"InvalidSchema getting filetype for {url}", extra={
+                    "url": url,
+                    "headers": headers,
+                    "cookies": cookies,
+                    "proxies": proxies,
+                })
+                break
             except Exception as e:
                 logger.exception(f"General getting filetype from {url}", extra={
                     "url": url,


### PR DESCRIPTION
This pull request introduces improvements to the `base_scrapper.py` file, focusing on error handling, URL validation, and robustness in processing links. The most significant changes include adding a URL repair method, improving exception handling for invalid schemas, and enhancing the handling of HTTP response validation.

### Error handling improvements:
* Added specific handling for `requests.exceptions.InvalidSchema` in the `get_file_type_request` method to log detailed information and terminate the retry loop when this exception occurs.
* Modified the validation of the HTTP response in `get_file_type_request` to account for cases where the response is `None`, preventing potential `UnboundLocalError` when accessing `resp.status_code`.

### URL validation and processing:
* Introduced a new static method, `repair_url`, to fix URLs missing the protocol (e.g., adding the "h" to "ttp://"). This method uses a simple heuristic to address common URL formatting issues.
* Updated the `process_links` method to apply the `repair_url` function to all links, ensuring that invalid URLs are repaired before further processing.

### Miscellaneous:
* Initialized the `resp` variable to `None` at the start of the `get_file_type_request` method to ensure it is always defined, even if no request is successfully made.- **fix UnboundLocalError**
- **add repair url to fix england link issue**
- **catch invalid schema**
